### PR TITLE
Support Hanami with ROM apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
-# Hanami::Serializer
+# Hanami::Serializer for ROM
 
-Simple solution for serializing you data in hanami apps.
+Simple solution for serializing your data in hanami apps. 
+
+## Note
+
+Based on the [original work by davydovanton](https://github.com/davydovanton/hanami-serializer) (no longer maintained), this fork repository added the following changes to support Hanami apps which directly uses Ruby Object Mapper (ROM) without relying on Hanami::Model, a wrapper of ROM, as the ORM layer:
+* Made compatible with rom-core 5.1.2 or above
+* Upgraded the dependencies (dry-struct, dry-types)
+* Dropped support for hanami-model (at least for now; hanami-model still depends on very old versions of dry-struct and dry-types.)
+* Expanded test coverage
+
+## Index
 
 * [Installation](#installation)
 * [Usage](#usage)
@@ -135,6 +145,11 @@ serializer.call           # => '{ "id":1, "name": "anton" }'
 JSON.generate(serializer) # => '{ "id":1, "name": "anton" }'
 ```
 
+You can also use [oj](https://github.com/ohler55/oj) for faster object marshalling:
+```ruby
+Oj.dump(serializer, mode: :compat, use_to_json: true) # => '{ "id":1, "name": "anton" }'
+```
+
 ### Nested
 You can use nested data structures. You have 2 ways how to use it
 
@@ -147,7 +162,7 @@ class UserWithAvatarSerializer < Hanami::Serializer::Base
 
   attribute :avatar, Types::Hash.schema(
     upload_file_name: Types::String,
-    upload_file_size: Types::Coercible::Int
+    upload_file_size: Types::Coercible::Integer
   )
 end
 ```
@@ -158,7 +173,7 @@ We can user other serializer as a type for attribute:
 ```ruby
 class AvatarSerializer < Hanami::Serializer::Base
   attribute :upload_file_name, Types::String
-  attribute :upload_file_size, Types::Coercible::Int
+  attribute :upload_file_size, Types::Coercible::Integer
 end
 
 class NestedUserSerializer < Hanami::Serializer::Base

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+require 'hanami/serializer'
+require 'rom/core'
+
+module Types
+  include Dry.Types()
+end
+
+Dry::Struct.load_extensions(:pretty_print)
+
+require 'irb'
+IRB.start(__FILE__)

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/hanami-serializer.gemspec
+++ b/hanami-serializer.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dry-struct", "~> 1.2.0"
   spec.add_dependency "dry-types", "~> 1.2.0"
 
-  spec.add_development_dependency "hanami-model"
+  spec.add_development_dependency "rom-core", "~> 5.1.2"
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/hanami-serializer.gemspec
+++ b/hanami-serializer.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rom-core", "~> 5.1.2"
   spec.add_development_dependency "bundler", "~> 2.1"
+  spec.add_development_dependency "oj", "~> 3.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 end

--- a/hanami-serializer.gemspec
+++ b/hanami-serializer.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "dry-struct", "~> 0.4"
-  spec.add_dependency "dry-types", "~> 0.12"
+  spec.add_dependency "dry-struct", "~> 1.2.0"
+  spec.add_dependency "dry-types", "~> 1.2.0"
 
   spec.add_development_dependency "hanami-model"
   spec.add_development_dependency "bundler", "~> 2.1"

--- a/hanami-serializer.gemspec
+++ b/hanami-serializer.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "dry-struct"#, "~> 1.2.0"
-  spec.add_dependency "dry-types"#, "~> 1.2.0"
+  spec.add_runtime_dependency "dry-struct", "~> 1.0"
+  spec.add_runtime_dependency "dry-types", "~> 1.0"
 
   spec.add_development_dependency "rom-core", "~> 5.1.2"
   spec.add_development_dependency "bundler", "~> 2.1"

--- a/hanami-serializer.gemspec
+++ b/hanami-serializer.gemspec
@@ -22,11 +22,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "dry-struct"
-  spec.add_dependency "dry-types"
+  spec.add_dependency "dry-struct", "~> 0.4"
+  spec.add_dependency "dry-types", "~> 0.12"
 
   spec.add_development_dependency "hanami-model"
-  spec.add_development_dependency "bundler", "~> 1.13"
+  spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 end

--- a/hanami-serializer.gemspec
+++ b/hanami-serializer.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "dry-struct", "~> 1.2.0"
-  spec.add_dependency "dry-types", "~> 1.2.0"
+  spec.add_dependency "dry-struct"#, "~> 1.2.0"
+  spec.add_dependency "dry-types"#, "~> 1.2.0"
 
   spec.add_development_dependency "rom-core", "~> 5.1.2"
   spec.add_development_dependency "bundler", "~> 2.1"

--- a/lib/hanami/serializer/base.rb
+++ b/lib/hanami/serializer/base.rb
@@ -1,10 +1,12 @@
 require 'json'
+require 'dry-struct'
 
 module Hanami
   module Serializer
     class Base < Dry::Struct
-      transform_types do |type|
-        type.constructor { |value| value.nil? ? Undefined : value  }
+      transform_types do |schema_key|
+        # Type-safely handle nil values of a field with no default value defined.
+        schema_key.constructor { |value| value.nil? ? Dry::Types::Undefined : value }
       end
 
       class << self

--- a/lib/hanami/serializer/base.rb
+++ b/lib/hanami/serializer/base.rb
@@ -3,7 +3,7 @@ require 'json'
 module Hanami
   module Serializer
     class Base < Dry::Struct
-      constructor_type :weak
+      constructor_type :schema
 
       class << self
         def serialized_fields(attributes)

--- a/lib/hanami/serializer/base.rb
+++ b/lib/hanami/serializer/base.rb
@@ -3,7 +3,9 @@ require 'json'
 module Hanami
   module Serializer
     class Base < Dry::Struct
-      constructor_type :schema
+      transform_types do |type|
+        type.constructor { |value| value.nil? ? Undefined : value  }
+      end
 
       class << self
         def serialized_fields(attributes)

--- a/test/hanami/serializer_test.rb
+++ b/test/hanami/serializer_test.rb
@@ -1,45 +1,98 @@
 require 'test_helper'
 
+def serialization_output_must_be(expected_json_string)
+  it 'emits the expected json string' do
+    expect(serializer.to_json).must_equal expected_json_string
+    expect(serializer.call).must_equal expected_json_string
+    expect(JSON.generate(serializer)).must_equal expected_json_string
+    expect(Oj.dump(serializer, mode: :compat, use_to_json: true)).must_equal expected_json_string
+  end
+end
+
+def serialization_should_validation_error(message_pattern = nil)
+  it 'raises a schema validation error' do
+    error = assert_raises(Dry::Struct::Error) { serializer.to_json }
+    assert_match(message_pattern, error.message) if message_pattern
+    error = assert_raises(Dry::Struct::Error) { serializer.call }
+    assert_match(message_pattern, error.message) if message_pattern
+    error = assert_raises(Dry::Struct::Error) { JSON.generate(serializer) }
+    assert_match(message_pattern, error.message) if message_pattern
+    error = assert_raises(Dry::Struct::Error) { Oj.dump(serializer, mode: :compat, use_to_json: true) }
+    assert_match(message_pattern, error.message) if message_pattern
+  end
+end
+
 describe Hanami::Serializer do
   let(:serializer) { UserSerializer.new(object) }
 
   describe '#to_json' do
     describe 'works with empty hash' do
+      let(:serializer) { AnonymizableUserSerializer.new(object) }
       let(:object) { {} }
 
-      it { serializer.to_json.must_equal '{"name":null}' }
-      it { serializer.call.must_equal '{"name":null}' }
-      it { JSON.generate(serializer).must_equal '{"name":null}' }
+      serialization_output_must_be '{"name":null}'
     end
 
     describe 'works with hash' do
-      let(:object) { { id: 1, name: 'Anton' } }
+      describe 'having a required field with a default value' do
+        describe 'when the key is missing' do
+          let(:object) { { id: 1, email: 'test@site.com', subscribed: true } }
 
-      it { serializer.to_json.must_equal '{"name":"Anton"}' }
-      it { serializer.call.must_equal '{"name":"Anton"}' }
-      it { JSON.generate(serializer).must_equal '{"name":"Anton"}' }
+          serialization_output_must_be '{"name":"","email":"test@site.com","subscribed":true}'
+        end
+
+        describe 'when the value is missing' do
+          let(:object) { { id: 1, name: nil, email: 'test@site.com', subscribed: true } }
+
+          serialization_output_must_be '{"name":"","email":"test@site.com","subscribed":true}'
+        end
+      end
+
+      describe 'having a required field without a default value' do
+        describe 'when the key is missing' do
+          let(:object) { { id: 1, name: 'Anton', subscribed: true } }
+
+          serialization_should_validation_error /email is missing/
+        end
+
+        describe 'when the value is missing' do
+          let(:object) { { id: 1, name: 'Anton', email: nil, subscribed: true } }
+
+          serialization_should_validation_error /email violates constraints/
+        end
+      end
+
+      describe 'having an optional field with a default value' do
+        describe 'when the key is missing' do
+          let(:object) { { id: 1, name: 'Anton', email: 'test@site.com' } }
+
+          serialization_output_must_be '{"name":"Anton","email":"test@site.com","subscribed":false}'
+        end
+
+        describe 'when the value is missing' do
+          let(:object) { { id: 1, name: 'Anton', email: 'test@site.com', subscribed: nil } }
+
+          serialization_output_must_be '{"name":"Anton","email":"test@site.com","subscribed":false}'
+        end
+      end
     end
 
-    describe 'works with hanami-entity' do
+    describe 'works with rom-entity' do
       let(:object) { User.new(id: 1, name: 'Anton', email: 'test@site.com', created_at: Time.now) }
 
-      it { serializer.to_json.must_equal '{"name":"Anton"}' }
-      it { serializer.call.must_equal '{"name":"Anton"}' }
-      it { JSON.generate(serializer).must_equal '{"name":"Anton"}' }
+      serialization_output_must_be '{"name":"Anton","email":"test@site.com","subscribed":false}'
     end
 
     describe 'works with nested data' do
       let(:serializer) { UserWithAvatarSerializer.new(object) }
 
-      describe 'for emplt nested data' do
+      describe 'for empty nested data' do
         let(:object) { { id: 1, name: 'Anton', email: 'test@site.com', created_at: Time.now } }
 
-        it { serializer.to_json.must_equal '{"name":"Anton","avatar":{}}' }
-        it { serializer.call.must_equal '{"name":"Anton","avatar":{}}' }
-        it { JSON.generate(serializer).must_equal '{"name":"Anton","avatar":{}}' }
+        serialization_output_must_be '{"name":"Anton","avatar":{}}'
       end
 
-      describe 'for emplt nested data' do
+      describe 'for empty nested data' do
         let(:object) do
           {
             id: 1,
@@ -54,24 +107,21 @@ describe Hanami::Serializer do
           }
         end
 
-        it { serializer.to_json.must_equal '{"name":"Anton","avatar":{"upload_file_name":"test.jpg","upload_file_size":10}}' }
-        it { serializer.call.must_equal '{"name":"Anton","avatar":{"upload_file_name":"test.jpg","upload_file_size":10}}' }
-        it { JSON.generate(serializer).must_equal '{"name":"Anton","avatar":{"upload_file_name":"test.jpg","upload_file_size":10}}' }
+        serialization_output_must_be \
+          '{"name":"Anton","avatar":{"upload_file_name":"test.jpg","upload_file_size":10}}'
       end
     end
 
     describe 'works with nested serializer' do
       let(:serializer) { NestedUserSerializer.new(object) }
 
-      describe 'for emplt nested data' do
+      describe 'for empty nested data' do
         let(:object) { { id: 1, name: 'Anton', email: 'test@site.com', created_at: Time.now } }
 
-        it { serializer.to_json.must_equal '{"name":"Anton","avatar":null}' }
-        it { serializer.call.must_equal '{"name":"Anton","avatar":null}' }
-        it { JSON.generate(serializer).must_equal '{"name":"Anton","avatar":null}' }
+        serialization_output_must_be '{"name":"Anton","avatar":{}}'
       end
 
-      describe 'for emplt nested data' do
+      describe 'for empty nested data' do
         let(:object) do
           {
             id: 1,
@@ -86,9 +136,8 @@ describe Hanami::Serializer do
           }
         end
 
-        it { serializer.to_json.must_equal '{"name":"Anton","avatar":{"upload_file_name":"test.jpg","upload_file_size":10}}' }
-        it { serializer.call.must_equal '{"name":"Anton","avatar":{"upload_file_name":"test.jpg","upload_file_size":10}}' }
-        it { JSON.generate(serializer).must_equal '{"name":"Anton","avatar":{"upload_file_name":"test.jpg","upload_file_size":10}}' }
+        serialization_output_must_be \
+          '{"name":"Anton","avatar":{"upload_file_name":"test.jpg","upload_file_size":10}}'
       end
     end
 
@@ -108,7 +157,7 @@ describe Hanami::Serializer do
         }
       end
 
-      it { serializer.to_json.must_equal '{"name":"Anton"}' }
+      serialization_output_must_be '{"name":"Anton"}'
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,7 +17,7 @@ class User < ROM::Struct
   attribute :id,         Types::Integer
   attribute :name,       Types::String
   attribute :email,      Types::String
-  attribute? :has_pet,         Types::Bool
+  attribute? :has_pet,   Types::Bool
   attribute :created_at, Types::Time
 end
 
@@ -26,8 +26,8 @@ class AnonymizableUserSerializer < Hanami::Serializer::Base
 end
 
 class UserSerializer < Hanami::Serializer::Base
-  attribute :name,  Types::String.default { ''.freeze }
-  attribute :email, Types::String
+  attribute :name,        Types::String.default { ''.freeze }
+  attribute :email,       Types::String
   attribute? :subscribed, Types::Bool.default { false }
 end
 
@@ -55,6 +55,6 @@ class AvatarSerializer < Hanami::Serializer::Base
 end
 
 class NestedUserSerializer < Hanami::Serializer::Base
-  attribute :name, Types::String
-  attribute? :avatar,    AvatarSerializer.default { {}.freeze }
+  attribute :name,    Types::String
+  attribute? :avatar, AvatarSerializer.default { {}.freeze }
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,43 +1,49 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'dry-types'
 require 'dry-struct'
+require 'rom/core'
+require 'oj'
 
 require 'hanami/serializer'
-require 'hanami/model'
 
 require 'minitest/spec'
 require 'minitest/autorun'
 
 module Types
-  include Dry::Types.module
+  include Dry.Types()
 end
 
-class User < Hanami::Entity
-  attributes do
-    attribute :id,         Types::Int
-    attribute :name,       Types::String
-    attribute :email,      Types::String
-    attribute :created_at, Types::Time
-  end
+class User < ROM::Struct
+  attribute :id,         Types::Integer
+  attribute :name,       Types::String
+  attribute :email,      Types::String
+  attribute? :has_pet,         Types::Bool
+  attribute :created_at, Types::Time
+end
+
+class AnonymizableUserSerializer < Hanami::Serializer::Base
+  attribute :name, Types::String.default { nil }
 end
 
 class UserSerializer < Hanami::Serializer::Base
-  attribute :name, Types::String
+  attribute :name,  Types::String.default { ''.freeze }
+  attribute :email, Types::String
+  attribute? :subscribed, Types::Bool.default { false }
 end
 
 class UserWithAvatarSerializer < Hanami::Serializer::Base
   attribute :name, Types::String
 
   attribute :avatar, Types::Hash.schema(
-    upload_file_name: Types::String,
-    upload_file_size: Types::Coercible::Int
-  ).default({})
+    upload_file_name?: Types::String,
+    upload_file_size?: Types::Coercible::Integer
+  ).default { {}.freeze }
 end
 
 class UserWithSelectedFieldsSerializer < Hanami::Serializer::Base
-  attribute :id, Types::Int
-  attribute :name, Types::String
-  attribute :email, Types::String
+  attribute :id,         Types::Integer
+  attribute :name,       Types::String
+  attribute :email,      Types::String
   attribute :created_at, Types::Time
 
   serialized_fields [:name]
@@ -45,10 +51,10 @@ end
 
 class AvatarSerializer < Hanami::Serializer::Base
   attribute :upload_file_name, Types::String
-  attribute :upload_file_size, Types::Coercible::Int
+  attribute :upload_file_size, Types::Coercible::Integer
 end
 
 class NestedUserSerializer < Hanami::Serializer::Base
   attribute :name, Types::String
-  attribute :avatar, AvatarSerializer
+  attribute? :avatar,    AvatarSerializer.default { {}.freeze }
 end


### PR DESCRIPTION
Based on the original work by davydovanton, I added the following changes to support Hanami apps which directly uses Ruby Object Mapper (ROM) without relying on Hanami::Model, a wrapper of ROM, as the ORM layer:
* Made compatible with rom-core 5.1.2 or above
* Upgraded the dependencies (dry-struct ~> 1.0, dry-types ~> 1.0)
* Dropped support for hanami-model (at least for now; hanami-model still depends on very old versions of dry-struct and dry-types.)
* Expanded test coverage