### PR TITLE
Add a benchmark comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Based on the [original work by davydovanton](https://github.com/davydovanton/han
 * Made compatible with rom-core 5.1.2 or above
 * Upgraded the dependencies (dry-struct, dry-types)
 * Dropped support for hanami-model (at least for now; hanami-model still depends on very old versions of dry-struct and dry-types.)
+* Added a configurable option to switch the JSON marshalling engine from Ruby's builtin JSON to Oj
 * Expanded test coverage
 
 ## Index
@@ -148,6 +149,11 @@ JSON.generate(serializer) # => '{ "id":1, "name": "anton" }'
 You can also use [oj](https://github.com/ohler55/oj) for faster object marshalling:
 ```ruby
 Oj.dump(serializer, mode: :compat, use_to_json: true) # => '{ "id":1, "name": "anton" }'
+```
+or equivalently
+```ruby
+Hanami::Serializer.config.json_engine = :oj
+serializer.to_json # => '{ "id":1, "name": "anton" }'
 ```
 
 ### Nested

--- a/benchmark/marshallers.rb
+++ b/benchmark/marshallers.rb
@@ -1,0 +1,240 @@
+# !/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'benchmark/ips'
+require_relative '../lib/hanami/serializer'
+require 'rom/core'
+require 'oj'
+require 'active_model'
+require 'fast_jsonapi'
+
+module Types
+  include Dry.Types()
+end
+
+num_users = 100
+
+class UserStruct < ROM::Struct
+  attribute :id, Types::Integer
+  attribute :name, Types::String
+  attribute :email, Types::String
+  attribute? :has_pet, Types::Bool
+  attribute :created_at, Types::Time
+  attribute :avatar, Types::Hash.schema(
+    upload_file_name?: Types::String,
+    upload_file_size?: Types::Coercible::Integer
+  ).default { {}.freeze }
+  attribute :articles, Types::Array.of(Types::Hash.schema(
+    title: Types::String,
+    posted_at: Types::Time
+  ))
+end
+class AvatarHanamiSerializer < Hanami::Serializer::Base
+  attribute :upload_file_name, Types::String
+  attribute :upload_file_size, Types::Coercible::Integer
+end
+class ArticleHanamiSerializer < Hanami::Serializer::Base
+  attribute :title, Types::String
+  attribute :posted_at, Types::Time
+end
+class UserHanamiSerializer < Hanami::Serializer::Base
+  attribute :name, Types::String
+  attribute :email, Types::String
+  attribute? :avatar, AvatarHanamiSerializer.default { {}.freeze }
+  attribute :articles, Types::Array.of(ArticleHanamiSerializer)
+end
+class UsersHanamiSerializer < Hanami::Serializer::Base
+  attribute :users, Types::Array.of(UserHanamiSerializer)
+end
+struct_users = {
+  users: Array.new(num_users) { |user_id|
+    UserStruct.new(
+      id: user_id,
+      name: 'John Doe',
+      email: 'jd@example.com',
+      created_at: Time.now,
+      avatar: {
+        id: 1,
+        upload_file_name: 'test.jpg',
+        upload_file_size: 10,
+        upload_updated_at: Time.now
+      },
+      articles: [
+        {
+          title: '10 Ruby performance tips',
+          posted_at: Time.now
+        },
+        {
+          title: 'Ruby 2.7 pattern matching examples',
+          posted_at: Time.now
+        }
+      ]
+    )
+  }
+}
+
+class ActiveModelBase
+  include ::ActiveModel::Model
+  include ::ActiveModel::Attributes
+  include ::ActiveModel::Serializers::JSON
+end
+class UserActiveModel < ActiveModelBase
+  attribute :id, :integer
+  attribute :name, :string
+  attribute :email, :string
+  attribute :created_at, :time
+  attribute :avatar
+  attribute :articles
+end
+class AvatarActiveModel < ActiveModelBase
+  attribute :upload_file_name, :string
+  attribute :upload_file_size, :integer
+end
+class ArticleActiveModel < ActiveModelBase
+  attribute :title, :string
+  attribute :posted_at, :time
+end
+active_model_users = {
+  users: Array.new(num_users) { |user_id|
+    UserActiveModel.new(
+      id: user_id,
+      name: 'John Doe',
+      email: 'jd@example.com',
+      created_at: Time.now,
+      avatar: AvatarActiveModel.new(
+        upload_file_name: 'test.jpg',
+        upload_file_size: 10
+      ),
+      articles: [
+        ArticleActiveModel.new(
+          title: '10 Ruby performance tips',
+          posted_at: Time.now
+        ),
+        ArticleActiveModel.new(
+          title: 'Ruby 2.7 pattern matching examples',
+          posted_at: Time.now
+        )
+      ]
+    )
+  }
+}
+
+class User
+  attr_accessor :id, :name, :email, :created_at, :avatar, :articles, :avatar_id, :article_ids
+  def initialize(id:, name:, email:, created_at:, avatar:, articles:)
+    @id, @name, @email, @created_at, @avatar, @articles = id, name, email, created_at, avatar, articles
+    @avatar_id = avatar.id
+    @article_ids = articles.map(&:id)
+  end
+end
+class Avatar
+  attr_accessor :id, :upload_file_name, :upload_file_size, :upload_updated_at
+  def initialize(id:, upload_file_name:, upload_file_size:, upload_updated_at:)
+    @id, @upload_file_name, @upload_file_size, @upload_updated_at = id, upload_file_name, upload_file_size, upload_updated_at
+  end
+end
+class Article
+  attr_accessor :id, :title, :posted_at
+  def initialize(id:, title:, posted_at:)
+    @id, @title, @posted_at = id, title, posted_at
+  end
+end
+class UserSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :id, :name, :email, :created_at, :avatar
+  has_one :avatar
+  has_many :articles
+end
+class AvatarSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :id, :upload_file_name, :upload_file_size
+end
+class ArticleSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :id, :title, :posted_at
+end
+obj_users = Array.new(num_users) { |user_id|
+  User.new(
+    id: user_id,
+    name: 'John Doe',
+    email: 'jd@example.com',
+    created_at: Time.now,
+    avatar: Avatar.new(id: 1, upload_file_name: 'test.jpg', upload_file_size: 10, upload_updated_at: Time.now),
+    articles: (1..3).map { |i|
+      Article.new(id: i, title: "title#{i}", posted_at: Time.now)
+    }
+  )
+}
+
+hash_users = {
+  users: Array.new(num_users) { |user_id|
+    {
+      id: user_id,
+      name: 'John Doe',
+      email: 'jd@example.com',
+      created_at: Time.now,
+      avatar: {
+        upload_file_name: 'test.jpg',
+        upload_file_size: 10,
+        upload_updated_at: Time.now
+      },
+      articles: [
+        {
+          title: '10 Ruby performance tips',
+          posted_at: Time.now
+        },
+        {
+          title: 'Ruby 2.7 pattern matching examples',
+          posted_at: Time.now
+        }
+      ]
+    }
+  }
+}
+
+Benchmark.ips do |x|
+  x.config(warmup: 2, time: 10)
+  x.config(stats: :bootstrap, confidence: 95)
+
+  x.report('Hanami::Serializer') do
+    UsersHanamiSerializer.new(struct_users).to_json
+  end
+
+  x.report('Hanami::Serializer(oj)') do
+    Hanami::Serializer.config.json_engine = :oj
+    UsersHanamiSerializer.new(struct_users).to_json
+  end
+
+  x.report('ActiveModel::Serializers') do
+    active_model_users.to_json
+  end
+
+  x.report('FastJsonapi') do
+    UserSerializer.new(obj_users, include: [:avatar, :articles]).serialized_json
+  end
+
+  x.report('Hash#to_json') do
+    hash_users.to_json
+  end
+
+  x.compare!
+end
+
+__END__
+
+Benchmark results
+
+  Hanami::Serializer      127.028  (± 5.7%) i/s -      1.206k in  10.166371s
+Hanami::Serializer(oj)    161.131  (± 1.0%) i/s -      1.608k in  10.015838s
+ActiveModel::Serializers  126.964  (± 2.5%) i/s -      1.224k in  10.027166s
+         FastJsonapi       75.282  (± 2.6%) i/s -        732  in  10.013214s
+        Hash#to_json      107.377  (± 5.2%) i/s -      1.035k in  10.126912s
+                   with 95.0% confidence
+
+Comparison:
+Hanami::Serializer(oj):        161.1 i/s
+  Hanami::Serializer:          127.0 i/s - 1.27x  (± 0.07) slower
+ActiveModel::Serializers:      127.0 i/s - 1.27x  (± 0.03) slower
+        Hash#to_json:          107.4 i/s - 1.50x  (± 0.08) slower
+         FastJsonapi:           75.3 i/s - 2.14x  (± 0.06) slower
+                   with 95.0% confidence

--- a/hanami-serializer.gemspec
+++ b/hanami-serializer.gemspec
@@ -25,9 +25,13 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "dry-struct", "~> 1.0"
   spec.add_runtime_dependency "dry-types", "~> 1.0"
 
-  spec.add_development_dependency "rom-core", "~> 5.1.2"
+  spec.add_development_dependency "activemodel", "~> 6.0"
+  spec.add_development_dependency "benchmark-ips"
   spec.add_development_dependency "bundler", "~> 2.1"
+  spec.add_development_dependency "fast_jsonapi", "~> 1.5"
+  spec.add_development_dependency "kalibera"
+  spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "oj", "~> 3.10"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "rom-core", "~> 5.1.2"
 end

--- a/lib/hanami/serializer.rb
+++ b/lib/hanami/serializer.rb
@@ -1,9 +1,10 @@
-require "hanami/serializer/base"
-require "hanami/serializer/action"
-require "hanami/serializer/version"
+require 'hanami/serializer/config'
+require 'hanami/serializer/base'
+require 'hanami/serializer/action'
+require 'hanami/serializer/version'
 
 module Hanami
   module Serializer
-    # Your code goes here...
+    extend Configurable
   end
 end

--- a/lib/hanami/serializer/action.rb
+++ b/lib/hanami/serializer/action.rb
@@ -3,7 +3,7 @@ module Hanami
     module Action
       def send_json(response, status: 200)
         self.status = status
-        self.body = JSON.generate(response)
+        self.body = response.respond_to?(:to_json) ? response.to_json : JSON.generate(response)
       end
 
       def serializer

--- a/lib/hanami/serializer/base.rb
+++ b/lib/hanami/serializer/base.rb
@@ -1,4 +1,3 @@
-require 'json'
 require 'dry-struct'
 
 module Hanami
@@ -25,7 +24,11 @@ module Hanami
       end
 
       def to_json(_ = nil)
-        JSON.generate(attributes_for_serialize(to_h))
+        if Hanami::Serializer.config.json_engine == :oj && defined?(Oj)
+          Oj.dump(attributes_for_serialize(to_h), mode: :compat, use_to_json: true)
+        else
+          JSON.generate(attributes_for_serialize(to_h))
+        end
       end
       alias_method :call, :to_json
 

--- a/lib/hanami/serializer/config.rb
+++ b/lib/hanami/serializer/config.rb
@@ -1,0 +1,31 @@
+require 'json'
+
+module Hanami
+  module Serializer
+    class Config
+      attr_accessor :json_engine
+
+      def initialize
+        # JSON Engine for Ruby object marshalling
+        # Available options:
+        #   nil  JSON in Ruby's standard library
+        #   :oj  Oj (a high performance alternative gem written in C)
+        @json_engine = nil
+      end
+    end
+
+    module Configurable
+      class << self
+        attr_accessor :config
+      end
+
+      def config
+        @config ||= Config.new
+      end
+
+      def configure
+        yield config
+      end
+    end
+  end
+end


### PR DESCRIPTION
I have added a benchmark script which roughly compares performance of JSON serialization using Hanami::Serializer (this gem), Hanami::Serializer with Oj, ActiveModel::Serializers, and FastJsonapi.
To make the JSON marshaling engine swappable, a configuration option (`Hanami::Serializer.config.json_engine`) is also added.